### PR TITLE
Ensure that the queue is always being consumed, thus avoiding drop head messages

### DIFF
--- a/src/main/scala/au/com/titanclass/streams/telemetry/MetricsReporter.scala
+++ b/src/main/scala/au/com/titanclass/streams/telemetry/MetricsReporter.scala
@@ -19,7 +19,7 @@ import java.util
 import java.util.concurrent.{ ScheduledExecutorService, TimeUnit }
 
 import akka.NotUsed
-import akka.stream.{ Materializer, OverflowStrategy }
+import akka.stream.{ Attributes, Materializer, OverflowStrategy }
 import akka.stream.scaladsl.{ BroadcastHub, Keep, Source }
 import com.codahale.metrics._
 
@@ -50,7 +50,7 @@ class MetricsReporter(registry: MetricRegistry,
   import MetricsReporter._
 
   private val (snapshotQueue, snapshotSource) = Source
-    .queue[MetricsSnapshot](1, OverflowStrategy.dropHead)
+    .queue[MetricsSnapshot](1, OverflowStrategy.dropHead.withLogLevel(Attributes.LogLevels.Off))
     .toMat(BroadcastHub.sink(1))(Keep.both)
     .run()
 

--- a/src/main/scala/au/com/titanclass/streams/telemetry/TracingJsonProtocol.scala
+++ b/src/main/scala/au/com/titanclass/streams/telemetry/TracingJsonProtocol.scala
@@ -51,20 +51,21 @@ object TracingJsonProtocol extends DefaultJsonProtocol {
                 case null =>
                   Vector.empty
                 case logs =>
-                  logs.asScala.map { x =>
-                    val fields = Map(
-                      "time" -> JsNumber(x.getTime),
-                      "fields" -> JsObject(
-                        x.getFields match {
-                          case null => Map.empty[String, JsValue]
-                          case f    => f.asScala.map(x => x._1 -> JsString(x._2.toString)).toMap
-                        }
-                      )
-                    ) ++ (x.getMessage match {
-                      case null => Map.empty[String, JsValue]
-                      case m    => Map("message" -> JsString(m))
-                    })
-                    JsObject(fields)
+                  logs.asScala.map {
+                    x =>
+                      val fields = Map[String, JsValue](
+                        "time" -> JsNumber(x.getTime),
+                        "fields" -> JsObject(
+                          x.getFields match {
+                            case null => Map.empty[String, JsValue]
+                            case f    => f.asScala.map(x => x._1 -> JsString(x._2.toString)).toMap
+                          }
+                        )
+                      ) ++ (x.getMessage match {
+                        case null => Map.empty[String, JsValue]
+                        case m    => Map("message" -> JsString(m))
+                      })
+                      JsObject(fields)
                   }.toVector
               }
             ),

--- a/src/main/scala/au/com/titanclass/streams/telemetry/TracingReporter.scala
+++ b/src/main/scala/au/com/titanclass/streams/telemetry/TracingReporter.scala
@@ -16,7 +16,7 @@
 
 package au.com.titanclass.streams.telemetry
 import akka.NotUsed
-import akka.stream.{ KillSwitches, Materializer, OverflowStrategy }
+import akka.stream.{ Attributes, KillSwitches, Materializer, OverflowStrategy }
 import akka.stream.scaladsl.{ BroadcastHub, Keep, Source }
 import io.jaegertracing.reporters.Reporter
 import io.jaegertracing.{ Span => JaegerSpan }
@@ -28,7 +28,7 @@ import io.opentracing.Span
 class TracingReporter(bufferSize: Int)(implicit mat: Materializer) extends Reporter {
 
   private val ((tracerQueue, killSwitch), tracerSource) = Source
-    .queue[Span](bufferSize, OverflowStrategy.dropHead)
+    .queue[Span](bufferSize, OverflowStrategy.dropHead.withLogLevel(Attributes.LogLevels.Off))
     .viaMat(KillSwitches.single)(Keep.both)
     .toMat(BroadcastHub.sink(1))(Keep.both)
     .run()


### PR DESCRIPTION
Per title. They're still technically possible of course, but in the general case this will avoid confusion when debugging other issues.